### PR TITLE
Fixed deprecation warning when adding range to selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function copy(text, options) {
     document.body.appendChild(mark);
 
     range.selectNode(mark);
+    selection.removeAllRanges();
     selection.addRange(range);
 
     var successful = document.execCommand('copy');


### PR DESCRIPTION
This fixes a deprecation warning, which is causing two clicks to be required when copying text sometimes.  The original repo is not well maintained, and the CopyToClipboard react component depends on this.